### PR TITLE
Applies models from server from OCUK-Strpai repo to the OR-UK repo

### DIFF
--- a/api/event/config/routes.json
+++ b/api/event/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/events",
+      "handler": "event.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/events/count",
+      "handler": "event.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/events/:id",
+      "handler": "event.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/events",
+      "handler": "event.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/events/:id",
+      "handler": "event.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/events/:id",
+      "handler": "event.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/event/controllers/event.js
+++ b/api/event/controllers/event.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/event/models/event.js
+++ b/api/event/models/event.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/event/models/event.settings.json
+++ b/api/event/models/event.settings.json
@@ -1,0 +1,36 @@
+{
+  "kind": "collectionType",
+  "collectionName": "eventsTest",
+  "info": {
+    "name": "event",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "unique": true,
+      "maxLength": 200
+    },
+    "body": {
+      "type": "richtext",
+      "required": true
+    },
+    "image": {
+      "collection": "file",
+      "via": "related",
+      "allowedTypes": [
+        "files",
+        "images",
+        "videos"
+      ],
+      "plugin": "upload",
+      "required": false
+    }
+  }
+}

--- a/api/event/services/event.js
+++ b/api/event/services/event.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/api/landing-page/config/routes.json
+++ b/api/landing-page/config/routes.json
@@ -1,0 +1,28 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/landing-page",
+      "handler": "landing-page.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/landing-page",
+      "handler": "landing-page.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/landing-page",
+      "handler": "landing-page.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/landing-page/controllers/landing-page.js
+++ b/api/landing-page/controllers/landing-page.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/landing-page/models/landing-page.js
+++ b/api/landing-page/models/landing-page.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/landing-page/models/landing-page.settings.json
+++ b/api/landing-page/models/landing-page.settings.json
@@ -1,0 +1,41 @@
+{
+  "kind": "singleType",
+  "collectionName": "landing_pages",
+  "info": {
+    "name": "landingPage",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "projectOverview": {
+      "type": "richtext",
+      "required": true
+    },
+    "logo": {
+      "collection": "file",
+      "via": "related",
+      "allowedTypes": [
+        "files",
+        "images",
+        "videos"
+      ],
+      "plugin": "upload",
+      "required": false
+    },
+    "sub_menu": {
+      "model": "sub-menu"
+    },
+    "top_menu": {
+      "model": "top-menu"
+    }
+  }
+}

--- a/api/landing-page/services/landing-page.js
+++ b/api/landing-page/services/landing-page.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/api/sub-menu/config/routes.json
+++ b/api/sub-menu/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/sub-menus",
+      "handler": "sub-menu.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/sub-menus/count",
+      "handler": "sub-menu.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/sub-menus/:id",
+      "handler": "sub-menu.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/sub-menus",
+      "handler": "sub-menu.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/sub-menus/:id",
+      "handler": "sub-menu.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/sub-menus/:id",
+      "handler": "sub-menu.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/sub-menu/controllers/sub-menu.js
+++ b/api/sub-menu/controllers/sub-menu.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/sub-menu/models/sub-menu.js
+++ b/api/sub-menu/models/sub-menu.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/sub-menu/models/sub-menu.settings.json
+++ b/api/sub-menu/models/sub-menu.settings.json
@@ -1,0 +1,23 @@
+{
+  "kind": "collectionType",
+  "collectionName": "sub_menus",
+  "info": {
+    "name": "SubMenu",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "MenuItem": {
+      "type": "component",
+      "repeatable": true,
+      "component": "menu.top-menu"
+    },
+    "Name": {
+      "type": "string"
+    }
+  }
+}

--- a/api/sub-menu/services/sub-menu.js
+++ b/api/sub-menu/services/sub-menu.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/api/top-menu/config/routes.json
+++ b/api/top-menu/config/routes.json
@@ -1,0 +1,52 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/top-menus",
+      "handler": "top-menu.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/top-menus/count",
+      "handler": "top-menu.count",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/top-menus/:id",
+      "handler": "top-menu.findOne",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/top-menus",
+      "handler": "top-menu.create",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/top-menus/:id",
+      "handler": "top-menu.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/top-menus/:id",
+      "handler": "top-menu.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/top-menu/controllers/top-menu.js
+++ b/api/top-menu/controllers/top-menu.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/top-menu/models/top-menu.js
+++ b/api/top-menu/models/top-menu.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/top-menu/models/top-menu.settings.json
+++ b/api/top-menu/models/top-menu.settings.json
@@ -1,0 +1,27 @@
+{
+  "kind": "collectionType",
+  "collectionName": "top_menus",
+  "info": {
+    "name": "TopMenu",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "link": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    },
+    "sub_menu": {
+      "model": "sub-menu"
+    },
+    "ShowOnFooter": {
+      "type": "boolean"
+    }
+  }
+}

--- a/api/top-menu/services/top-menu.js
+++ b/api/top-menu/services/top-menu.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/components/menu/top-menu.json
+++ b/components/menu/top-menu.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_menu_top_menus",
+  "info": {
+    "name": "MenuItem",
+    "icon": "code-branch",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "Label": {
+      "type": "string"
+    },
+    "Link": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
At the start of our Strapi process, we were using the deployed Strapi instance running in develop mode to build our content types.

This PR is work by @PorismDominicSkinner , in another repo, in which he retrieving the files that define the models. This PR brings that work into this repository.