### PR TITLE
Home page for CMS

### DIFF
--- a/api/home-page/config/routes.json
+++ b/api/home-page/config/routes.json
@@ -1,0 +1,28 @@
+{
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/home-page",
+      "handler": "home-page.find",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "PUT",
+      "path": "/home-page",
+      "handler": "home-page.update",
+      "config": {
+        "policies": []
+      }
+    },
+    {
+      "method": "DELETE",
+      "path": "/home-page",
+      "handler": "home-page.delete",
+      "config": {
+        "policies": []
+      }
+    }
+  ]
+}

--- a/api/home-page/controllers/home-page.js
+++ b/api/home-page/controllers/home-page.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-controllers)
+ * to customize this controller
+ */
+
+module.exports = {};

--- a/api/home-page/models/home-page.js
+++ b/api/home-page/models/home-page.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#lifecycle-hooks)
+ * to customize this model
+ */
+
+module.exports = {};

--- a/api/home-page/models/home-page.settings.json
+++ b/api/home-page/models/home-page.settings.json
@@ -1,0 +1,36 @@
+{
+  "kind": "singleType",
+  "collectionName": "home_page",
+  "info": {
+    "name": "Home Page",
+    "description": ""
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true,
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "heroBanner": {
+      "type": "component",
+      "repeatable": false,
+      "component": "common.hero-banner"
+    },
+    "introParagraph": {
+      "type": "richtext"
+    },
+    "PullQuote": {
+      "type": "component",
+      "repeatable": false,
+      "component": "common.pull-quote"
+    },
+    "BenefitsAndOpportunities": {
+      "type": "richtext"
+    },
+    "CommunityStatsBox": {
+      "type": "component",
+      "repeatable": false,
+      "component": "homepage.community-stats-box"
+    }
+  }
+}

--- a/api/home-page/services/home-page.js
+++ b/api/home-page/services/home-page.js
@@ -1,0 +1,8 @@
+'use strict';
+
+/**
+ * Read the documentation (https://strapi.io/documentation/developer-docs/latest/development/backend-customization.html#core-services)
+ * to customize this service
+ */
+
+module.exports = {};

--- a/components/common/hero-banner.json
+++ b/components/common/hero-banner.json
@@ -1,0 +1,16 @@
+{
+  "collectionName": "components_common_hero_banners",
+  "info": {
+    "name": "Hero Banner",
+    "icon": "smile"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "body": {
+      "type": "text"
+    }
+  }
+}

--- a/components/common/pull-quote.json
+++ b/components/common/pull-quote.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_common_pull_quotes",
+  "info": {
+    "name": "Pull Quote",
+    "icon": "quote-left",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "quote": {
+      "type": "text"
+    },
+    "Attribution": {
+      "type": "string"
+    }
+  }
+}

--- a/components/community/company-logo.json
+++ b/components/community/company-logo.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_community_company_logos",
+  "info": {
+    "name": "CompanyLogo",
+    "icon": "briefcase"
+  },
+  "options": {},
+  "attributes": {
+    "CompanyLogo": {
+      "model": "file",
+      "via": "related",
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos"
+      ],
+      "plugin": "upload",
+      "required": false
+    },
+    "link": {
+      "type": "string",
+      "regex": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)"
+    }
+  }
+}

--- a/components/homepage/community-stats-box.json
+++ b/components/homepage/community-stats-box.json
@@ -1,0 +1,27 @@
+{
+  "collectionName": "components_homepage_community_stats_boxes",
+  "info": {
+    "name": "Stats Box",
+    "icon": "digital-tachograph",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "numbers": {
+      "type": "component",
+      "repeatable": false,
+      "component": "homepage.numbers"
+    },
+    "OrganisationsIntroText": {
+      "type": "text"
+    },
+    "CompanyLogo": {
+      "type": "component",
+      "repeatable": true,
+      "component": "community.company-logo"
+    }
+  }
+}

--- a/components/homepage/numbers.json
+++ b/components/homepage/numbers.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_homepage_numbers",
+  "info": {
+    "name": "numbers",
+    "icon": "sort-numeric-up"
+  },
+  "options": {},
+  "attributes": {
+    "considering": {
+      "type": "integer"
+    },
+    "adopting": {
+      "type": "integer"
+    },
+    "adopted": {
+      "type": "integer"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds components and single content type for home page!

The `/home-page` API endpoint should output data like this atm:

```
{
  "id": 1,
  "published_at": "2021-04-09T16:15:33.000Z",
  "created_at": "2021-04-09T16:13:44.000Z",
  "updated_at": "2021-04-09T16:15:33.000Z",
  "introParagraph": "<h3>Open data standards for community services</h3><p>Local government organisations and services collect large amounts of information and data. This is presented in different formats and often collected multiple times and in inconsistent ways.&nbsp;</p><p>Adopting an <a href=\"#\">open data standard</a> helps to solve these problems.</p><p><br>&nbsp;</p>",
  "BenefitsAndOpportunities": "<ul><li>Easy to access, accurate and reliable information on services.</li><li>Save money and resources by capturing data once and enabling frontline workers and advocates to have the necessary information at their fingertips.</li><li>Users of the service get what they need and are not limited to one organisation - this is a more holistic approach rather than working in silos.</li><li>Partner with other local authorities, organisations and stakeholders to share information and knowledge.</li><li>Avoid duplication of information and ‘reinventing the wheel’ for every directory.</li><li>An opportunity for smaller or informal organisations to have a more level playing field for their services with some of the larger or more formal organisations.</li></ul>",
  "heroBanner": {},
  "PullQuote": {},
  "CommunityStatsBox": {}
}
```