### PR TITLE
Adds slugfield and short description to Case Study

### DIFF
--- a/api/case-studies/models/case-studies.settings.json
+++ b/api/case-studies/models/case-studies.settings.json
@@ -2,7 +2,8 @@
   "kind": "collectionType",
   "collectionName": "case_studies",
   "info": {
-    "name": "Case Studies"
+    "name": "Case Studies",
+    "description": ""
   },
   "options": {
     "increments": true,
@@ -14,6 +15,15 @@
       "type": "component",
       "repeatable": false,
       "component": "article.article"
+    },
+    "slugfield": {
+      "type": "string",
+      "regex": "^[a-z0-9-()]+$",
+      "unique": true,
+      "required": true
+    },
+    "description": {
+      "type": "text"
     }
   }
 }


### PR DESCRIPTION
Adds two new fields to the Case Study collection type:

- `slugfield` - this is being used to build the URLs as per [the URLs document](https://docs.google.com/document/d/19sb7Q-oO-KsEIi1HwJFMcAMiOEKYyDh2ktFzavkC1DA/edit#)
- `description` - this is a short overview description that has been introduced to the case study landing page in recent designs