### PR TITLE
Adds "Register" link to top of "Who's Using ORUK?" page

### DIFF
--- a/api/who-is-using-oruk-page/models/who-is-using-oruk-page.settings.json
+++ b/api/who-is-using-oruk-page/models/who-is-using-oruk-page.settings.json
@@ -19,7 +19,7 @@
       "repeatable": false,
       "component": "homepage.numbers"
     },
-    "registerLink": {
+    "registerLinkWithTitle": {
       "type": "component",
       "repeatable": false,
       "component": "common.link-with-title"
@@ -36,6 +36,11 @@
     },
     "underNumbersText": {
       "type": "string"
+    },
+    "registerLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "common.link"
     }
   }
 }


### PR DESCRIPTION
Adds a link that had previously been lost (I think due to duplicate naming of `registerLink` - sorry!🥴 ).