### PR TITLE
Adds case studies link and benefits section to content structure on home page

### DIFF
--- a/api/home-page/models/home-page.settings.json
+++ b/api/home-page/models/home-page.settings.json
@@ -36,6 +36,11 @@
       "type": "component",
       "repeatable": false,
       "component": "common.link"
+    },
+    "benefitsSection": {
+      "type": "component",
+      "repeatable": false,
+      "component": "common.list-with-icons"
     }
   }
 }

--- a/api/home-page/models/home-page.settings.json
+++ b/api/home-page/models/home-page.settings.json
@@ -31,6 +31,11 @@
       "type": "component",
       "repeatable": false,
       "component": "homepage.community-stats-box"
+    },
+    "caseStudiesLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "common.link"
     }
   }
 }

--- a/components/common/list-with-icons.json
+++ b/components/common/list-with-icons.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_common_list_with_icons",
+  "info": {
+    "name": "List with icons",
+    "icon": "list",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "introParagraph": {
+      "type": "text"
+    },
+    "benefits": {
+      "type": "component",
+      "repeatable": true,
+      "component": "common.text-with-icon"
+    },
+    "afterLinkParagraph": {
+      "type": "richtext"
+    }
+  }
+}

--- a/components/common/text-with-icon.json
+++ b/components/common/text-with-icon.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_common_text_with_icons",
+  "info": {
+    "name": "Text with icon",
+    "icon": "address-card"
+  },
+  "options": {},
+  "attributes": {
+    "icon": {
+      "model": "file",
+      "via": "related",
+      "allowedTypes": [
+        "images"
+      ],
+      "plugin": "upload",
+      "required": false
+    },
+    "benefitText": {
+      "type": "text"
+    }
+  }
+}


### PR DESCRIPTION
This PR:
- adds case studies link to homepage structure
- adds benefits section to home page, comprised of:
   - new "list with icons" component, which is in turn made up of:
   - new "text with icon" component