### PR TITLE
General CMS tidy

### DIFF
--- a/components/common/link.json
+++ b/components/common/link.json
@@ -15,6 +15,11 @@
     "url": {
       "type": "string",
       "required": true
+    },
+    "isExternal": {
+      "type": "boolean",
+      "required": true,
+      "default": false
     }
   }
 }

--- a/components/common/link.json
+++ b/components/common/link.json
@@ -7,7 +7,7 @@
   },
   "options": {},
   "attributes": {
-    "TextToDisplay": {
+    "textToDisplay": {
       "type": "string",
       "required": true,
       "unique": false


### PR DESCRIPTION
**!!! IMPORTANT**: This PR will cause breaking changes on the front-end. It should be merged and deployed simultaneously with the appropriate updates in the front end: [PR #118](https://github.com/WeAreSnook/OR-UK-frontend/pull/118).

**This will require manual DB change**, due to the case insensitive nature of MySQL. I've done this locally to test and have the commands ready to go on the deployed instance:

``` sql
ALTER TABLE components_common_links CHANGE TextToDisplay tempLink varchar(255);
ALTER TABLE components_common_links CHANGE tempLink textToDisplay varchar(255);
```

This PR:
- fixes casing on all link component's 'text to display' field (previously Pascal case `TextToDisplay`, now camel case `textToDisplay`)
- adds new boolean field `isExternal` to all link components
- removes footer logo from CMS
- allows for multiple 'get involved' links in footer