### PR TITLE
Fix casing on link's `textToDisplay` field

### DIFF
--- a/components/common/link.json
+++ b/components/common/link.json
@@ -7,7 +7,7 @@
   },
   "options": {},
   "attributes": {
-    "TextToDisplay": {
+    "textToDisplay": {
       "type": "string",
       "required": true,
       "unique": false


### PR DESCRIPTION
This should be merged and deployed simultaneously with the appropriate updates in the front end 

**This will require manual DB change**, due to the case insensitive nature of MySQL. I've done this locally to test and have the commands ready to go on the deployed instance:

```
ALTER TABLE components_common_links CHANGE TextToDisplay tempLink varchar(255);
ALTER TABLE components_common_links CHANGE tempLink textToDisplay varchar(255);

```

This PR:

- fixes casing on all link component's 'text to display' field (previously Pascal case `TextToDisplay`, now camel case `textToDisplay`)

(cherry picked from commit 88eb9137416d061f706ab33d6249296901d4d228)