### PR TITLE
Removes legacy `footerLogo` field from footer content structure

### DIFF
--- a/api/footer/models/footer.settings.json
+++ b/api/footer/models/footer.settings.json
@@ -46,17 +46,6 @@
       "repeatable": false,
       "component": "footer.footer-link"
     },
-    "footerLogo": {
-      "model": "file",
-      "via": "related",
-      "allowedTypes": [
-        "images",
-        "files",
-        "videos"
-      ],
-      "plugin": "upload",
-      "required": false
-    },
     "documentationAndToolsLinkLabel": {
       "type": "string"
     },


### PR DESCRIPTION
The `footerLogo` section has been in the CMS footer content structure since it was created, but it is no longer used (ORUK logo assets are part of client project).

This PR removes this section:

![image](https://user-images.githubusercontent.com/20354076/117159139-f40c4f80-adb7-11eb-8853-eb6e9db3976f.png)
